### PR TITLE
chore(router): warn in case of existent canary rule

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,6 +9,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Shows current build version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("1.0.5")
+		fmt.Println("1.0.6")
 	},
 }

--- a/pkg/router/virtualservice.go
+++ b/pkg/router/virtualservice.go
@@ -158,6 +158,12 @@ func (v *VirtualService) Update(s Shift) error {
 		if routeExists {
 			logger.Info("Found existent rule created for virtualService, skipping creation", v.TrackingId)
 
+			// If a canary rule already exists, just warn it
+			if len(s.Traffic.RequestHeaders) > 0 {
+				logger.Warn(fmt.Sprintf("Already existent canary rule for build '%v', refusing to update it", v.Build), v.TrackingId)
+			}
+
+			// If a weight rule already exists, just update it
 			if s.Traffic.Weight > 0 {
 				httpRoutes, err := Percentage(v.TrackingId, subsetName, vs.Spec.Http, s)
 				if err != nil {


### PR DESCRIPTION
In case of an update for existent canary rule, there was not logs
indicating this fact and the posterior 'update' log will get the process
even more confusing. As an additional step a warn log is given.

Issue #26