### PR TITLE
Feat/canary regexp support

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ istiops traffic shift \
     --headers "x-cid=seu_madruga"
 ```
 
+By default header's value is an exact match, you can configure to it's value matches a regular expression passing the flag `-r` or `--regexp`.
+
+Example for a rule which header `x-id` can be match by either `1`, `2`, `3` or `4`.
+
+`istiops ... -r -H 'x-id=1|2|3|4'`
+
 ### Shift to weight routing
 4. Send 20% of traffic to pods with labels `app=api-domain,build=PR-10`
 

--- a/cmd/shift.go
+++ b/cmd/shift.go
@@ -16,6 +16,9 @@ func init() {
 	shiftCmd.PersistentFlags().StringP("headers", "H", "", "headers")
 	shiftCmd.PersistentFlags().StringP("pod-selector", "p", "", "* pod")
 	shiftCmd.PersistentFlags().Uint32P("weight", "w", 0, "* weight (percentage) of routing")
+	// boolean optional flags
+	shiftCmd.PersistentFlags().BoolP("exact", "e", true, "exact header value (default flag)")
+	shiftCmd.PersistentFlags().BoolP("regexp", "r", false, "regexp header value (can't coexist with --exact flag")
 
 	_ = shiftCmd.MarkPersistentFlagRequired("destination")
 	_ = shiftCmd.MarkPersistentFlagRequired("pod-selector")
@@ -85,6 +88,15 @@ var shiftCmd = &cobra.Command{
 			}
 		}
 
+		var exact bool
+		var regexp bool
+		if cmd.Flag("regexp").Value.String() == "true" {
+			regexp = true
+			exact = false
+		} else {
+			exact = true
+		}
+
 		drR := router.DestinationRule{
 			TrackingId: trackingId,
 			Name:       destinationSplitted[0],
@@ -108,6 +120,8 @@ var shiftCmd = &cobra.Command{
 			Traffic: router.Traffic{
 				PodSelector:    mappedPodSelector,
 				RequestHeaders: headers,
+				Exact:          exact,
+				Regexp:         regexp,
 				Weight:         int32(weightInt),
 			},
 		}

--- a/cmd/shift.go
+++ b/cmd/shift.go
@@ -90,11 +90,11 @@ var shiftCmd = &cobra.Command{
 
 		var exact bool
 		var regexp bool
+
+		exact = true
 		if cmd.Flag("regexp").Value.String() == "true" {
 			regexp = true
 			exact = false
-		} else {
-			exact = true
 		}
 
 		drR := router.DestinationRule{

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -152,7 +152,17 @@ func beautified(irl router.IstioRouteList) {
 					//fmt.Println("* Match")
 					color.Cyan.Println("  \\_ Headers")
 					for headerKey, headerValue := range httpMatch.Headers {
-						fmt.Println(color.Cyan.Sprintf("      |- %s: %s", headerKey, headerValue))
+						var escapedHeaderValue string
+
+						if headerValue.GetExact() != "" {
+							escapedHeaderValue = fmt.Sprintf("%s", headerValue.GetExact())
+						}
+
+						if headerValue.GetRegex() != "" {
+							escapedHeaderValue = fmt.Sprintf("%s", headerValue.GetRegex())
+						}
+
+						fmt.Println(color.Cyan.Sprintf("      |- %s: %s", headerKey, escapedHeaderValue))
 					}
 				}
 			}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -150,19 +150,20 @@ func beautified(irl router.IstioRouteList) {
 
 				if len(httpMatch.Headers) > 0 {
 					//fmt.Println("* Match")
-					color.Cyan.Println("  \\_ Headers")
+					color.Cyan.Println("  \\_ Header")
 					for headerKey, headerValue := range httpMatch.Headers {
 						var escapedHeaderValue string
 
 						if headerValue.GetExact() != "" {
-							escapedHeaderValue = fmt.Sprintf("%s", headerValue.GetExact())
+							escapedHeaderValue = fmt.Sprintf("exact: %s", headerValue.GetExact())
 						}
 
 						if headerValue.GetRegex() != "" {
-							escapedHeaderValue = fmt.Sprintf("%s", headerValue.GetRegex())
+							escapedHeaderValue = fmt.Sprintf("regex: %s", headerValue.GetRegex())
 						}
 
-						fmt.Println(color.Cyan.Sprintf("      |- %s: %s", headerKey, escapedHeaderValue))
+						fmt.Println(color.Cyan.Sprintf("      |- %s", headerKey))
+						fmt.Println(color.Cyan.Sprintf("      |- %s", escapedHeaderValue))
 					}
 				}
 			}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -9,6 +9,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Shows current build version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("1.0.6")
+		fmt.Println("1.1.0")
 	},
 }

--- a/pkg/operator/istiops.go
+++ b/pkg/operator/istiops.go
@@ -71,10 +71,12 @@ func (ips *Istiops) Update(shift router.Shift) error {
 	if err != nil {
 		return err
 	}
+
 	err = DrRouter.Update(shift)
 	if err != nil {
 		return err
 	}
+
 	err = VsRouter.Update(shift)
 	if err != nil {
 		return err

--- a/pkg/router/destinationrule.go
+++ b/pkg/router/destinationrule.go
@@ -129,8 +129,11 @@ func (d *DestinationRule) Validate(s Shift) error {
 		return errors.New("empty pod selector")
 	}
 
-	return nil
+	if !s.Traffic.Exact && !s.Traffic.Regexp {
+		return errors.New("need 'exact' or 'regexp' flags")
+	}
 
+	return nil
 }
 
 /* Update a destinationRule with an existent subset based on Shift object
@@ -167,7 +170,7 @@ func (d *DestinationRule) Update(s Shift) error {
 				return err
 			}
 		} else {
-			logger.Info(fmt.Sprintf("subset '%s'already created", newSubset), d.TrackingId)
+			logger.Info(fmt.Sprintf("subset '%s' already created", newSubset), d.TrackingId)
 		}
 	}
 

--- a/pkg/router/destinationrule_test.go
+++ b/pkg/router/destinationrule_test.go
@@ -118,6 +118,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: nil,
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"empty label-selector",
@@ -135,6 +136,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"empty port",
@@ -152,6 +154,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"port not in range 1024 - 65535",
@@ -169,6 +172,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"port not in range 1024 - 65535",
@@ -184,7 +188,9 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Port:     8080,
 				Hostname: "api-domain",
 				Selector: map[string]string{"app": "api-domain"},
-				Traffic:  Traffic{},
+				Traffic:  Traffic{
+					Exact: true,
+				},
 			},
 			"empty pod selector",
 		},
@@ -201,6 +207,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"empty 'name' attribute",
@@ -218,6 +225,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"empty 'namespace' attribute",
@@ -235,6 +243,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"empty 'build' attribute",
@@ -252,6 +261,7 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"nil istioClient object",
@@ -269,9 +279,27 @@ func TestDestinationRule_Validate_Unit(t *testing.T) {
 				Selector: map[string]string{"app": "api-domain"},
 				Traffic: Traffic{
 					PodSelector: map[string]string{"version": "1.2.3"},
+					Exact: true,
 				},
 			},
 			"empty 'trackingId' attribute",
+		},
+		{DestinationRule{
+			TrackingId: "unit-testing-uuid",
+			Name:       "api-test",
+			Namespace:  "arrow",
+			Build:      1,
+			Istio:      fakeIstioClient,
+		},
+			Shift{
+				Port:     8080,
+				Hostname: "api-domain",
+				Selector: map[string]string{"app": "api-domain"},
+				Traffic: Traffic{
+					PodSelector: map[string]string{"version": "1.2.3"},
+				},
+			},
+			"need 'exact' or 'regexp' flags",
 		},
 	}
 

--- a/pkg/router/router.go
+++ b/pkg/router/router.go
@@ -23,6 +23,8 @@ type Shift struct {
 type Traffic struct {
 	PodSelector    map[string]string
 	RequestHeaders map[string]string
+	Exact          bool
+	Regexp         bool
 	Weight         int32
 }
 

--- a/pkg/router/virtualservice.go
+++ b/pkg/router/virtualservice.go
@@ -107,7 +107,7 @@ func (v *VirtualService) Create(s Shift) (*IstioRules, error) {
 		return &IstioRules{}, errors.New("can't create a new route without request header's match")
 	}
 
-	logger.Info(fmt.Sprintf("Setting request header's match rule '%s' for '%s'...", s.Traffic.RequestHeaders, subsetName), v.TrackingId)
+	logger.Info(fmt.Sprintf("Setting request header's match rule '%#v' for '%s'...", s.Traffic.RequestHeaders, subsetName), v.TrackingId)
 	newRoute.Match = append(newRoute.Match, newMatch)
 	newRoute.Route = append(newRoute.Route, defaultDestination)
 

--- a/pkg/router/virtualservice.go
+++ b/pkg/router/virtualservice.go
@@ -58,16 +58,34 @@ func (v *VirtualService) Create(s Shift) (*IstioRules, error) {
 	subsetName := fmt.Sprintf("%s-%v-%s", v.Name, v.Build, v.Namespace)
 
 	logger.Info(fmt.Sprintf("Creating new http route for subset '%s'...", subsetName), v.TrackingId)
-	newMatch := &v1alpha3.HTTPMatchRequest{
-		Headers: map[string]*v1alpha3.StringMatch{},
-	}
+	newMatch := &v1alpha3.HTTPMatchRequest{}
 
 	// append user labels to exact match
-	for headerKey, headerValue := range s.Traffic.RequestHeaders {
-		newMatch.Headers[headerKey] = &v1alpha3.StringMatch{
-			MatchType: &v1alpha3.StringMatch_Exact{
-				Exact: headerValue,
-			},
+	if s.Traffic.Regexp {
+		newMatch = &v1alpha3.HTTPMatchRequest{
+			Headers: map[string]*v1alpha3.StringMatch{},
+		}
+
+		for headerKey, headerValue := range s.Traffic.RequestHeaders {
+			newMatch.Headers[headerKey] = &v1alpha3.StringMatch{
+				MatchType: &v1alpha3.StringMatch_Regex{
+					Regex: headerValue,
+				},
+			}
+		}
+	}
+
+	if s.Traffic.Exact {
+		newMatch = &v1alpha3.HTTPMatchRequest{
+			Headers: map[string]*v1alpha3.StringMatch{},
+		}
+
+		for headerKey, headerValue := range s.Traffic.RequestHeaders {
+			newMatch.Headers[headerKey] = &v1alpha3.StringMatch{
+				MatchType: &v1alpha3.StringMatch_Exact{
+					Exact: headerValue,
+				},
+			}
 		}
 	}
 

--- a/pkg/router/virtualservice_test.go
+++ b/pkg/router/virtualservice_test.go
@@ -548,6 +548,7 @@ func TestVirtualService_Update_Integrated_NonExistentRoute_Headers_Regexp(t *tes
 			RequestHeaders: map[string]string{
 				"x-email": "^.+@domain.io",
 				"x-token": "^eebba923-750f-4b71-81fe-b91e026b7221$",
+				"x-escaped-string": "^(123\\|345)$",
 			},
 			Regexp: true,
 		},
@@ -572,6 +573,7 @@ func TestVirtualService_Update_Integrated_NonExistentRoute_Headers_Regexp(t *tes
 	assert.Equal(t, 1, len(re.Spec.Http[0].Match))
 	assert.Equal(t, shift.Traffic.RequestHeaders["x-email"], re.Spec.Http[0].Match[0].Headers["x-email"].GetRegex())
 	assert.Equal(t, shift.Traffic.RequestHeaders["x-token"], re.Spec.Http[0].Match[0].Headers["x-token"].GetRegex())
+	assert.Equal(t, "^(123\\|345)$", re.Spec.Http[0].Match[0].Headers["x-escaped-string"].GetRegex())
 	assert.Equal(t, fmt.Sprintf("%s-%v-%s", vs.Name, vs.Build, vs.Namespace), re.Spec.Http[0].Route[0].Destination.Subset)
 	assert.Equal(t, uint32(8888), re.Spec.Http[0].Route[0].Destination.Port.GetNumber())
 	assert.Equal(t, "api-service", re.Spec.Http[0].Route[0].Destination.Host)


### PR DESCRIPTION
We current have only one option for canary releases, setting a header's `key:value` with it's literal value but sometimes there is a need of getting `key:$REGULAR_EXPRESSION` instead. To attend this request this PR adds support to canary releases using regexp for it's value passing a flag `--regexp`.

Ex:

```
istiops traffic shift \
    -b 5 \
    -d api-mocked:8000 \
    -l app=api-mocked \
    -H 'blau=18534126|123|1023192' \
    -p version=1.1.1-n mock \
    --regexp
```

In this example a new rule will be set and if request' header value for `blau` is `18534126` or `123` or `1023192` it will be forwarded to `-p version=1.1.1`

The default value is `--exact`.