### PR TITLE
feat(istiops): add optional kubeconfig and context options to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [2.2.0] - 2020-11-23
+### Feature
+- add optional flags `context` and `kubeconfig` to the client.
+
 ## [2.1.0] - 2020-01-28
 ### Feature
 - add granular route `clear` modes: `soft` (default) & `hard`. More details at [documentation](https://github.com/pismo/istiops/blob/master/README.md). - [#19](https://github.com/pismo/istiops/issues/19)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,24 @@ istiops traffic shift \
     --weight 20
 ```
 
+## Global flags
+
+You can specify a custom path to you `kubeconfig` file or a specific kube-context from it by using respective the global flags: `--kubeconfig` and `--context`:
+
+```
+istiops traffic show \
+    -l "app=api-domain" \
+    -n "default" \
+    --kubeconfig "/tmp/kube-config"
+```
+
+```
+istiops traffic show \
+    -l "app=api-domain" \
+    -n "default" \
+    --context eks_eks-my-custom-context
+```
+
 ## Importing as a package
 
 You can assemble `istiops` as an interface for your own Golang code, to do it you just have to initialize the needed struct-dependencies and call the interface directly. You can see proper examples at `./examples`

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ istiops traffic shift \
 
 ## Global flags
 
-You can specify a custom path to you `kubeconfig` file or a specific kube-context from it by using respective the global flags: `--kubeconfig` and `--context`:
+You can specify a custom path to your `kubeconfig` file or a specific kube-context from it by using respective the global flags: `--kubeconfig` and `--context`:
 
 ```
 istiops traffic show \

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Istio Traffic Shifter (a.k.a `istiops`) is a tool to manage traffic for microser
     - [Clear all routes](#clear-all-routes)
     - [Headers routing](#shift-to-request-headers-routing)
     - [Weight Routing](#shift-to-weight-routing)
+* [Global Flags](#global-flags)
 * [Importing as a package](#importing-as-a-package)
 * [Contributing](#contributing)
 

--- a/cmd/clear.go
+++ b/cmd/clear.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/pismo/istiops/pkg/logger"
 	"github.com/pismo/istiops/pkg/router"
 	"github.com/spf13/cobra"
@@ -20,6 +21,9 @@ var rulesClearCmd = &cobra.Command{
 	Use:   "clear",
 	Short: "Removes all rules & routes except the master-one",
 	Run: func(cmd *cobra.Command, args []string) {
+		kubeContext, _ := rootCmd.Flags().GetString("context")
+		kubeConfigPath, _ := rootCmd.Flags().GetString("kubeconfig")
+		clientSetup(kubeContext, kubeConfigPath)
 
 		namespace := cmd.Flag("namespace").Value.String()
 		if namespace == "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/google/uuid"
 	"github.com/pismo/istiops/pkg/client"
 	"github.com/pismo/istiops/pkg/logger"
@@ -9,7 +11,6 @@ import (
 	"github.com/pismo/istiops/pkg/router"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/util/homedir"
-	"os"
 )
 
 var (
@@ -18,18 +19,22 @@ var (
 )
 
 func init() {
-	setup()
+	kubeConfigDefaultPath := homedir.HomeDir() + "/.kube/config"
+	rootCmd.PersistentFlags().String("context", "", "kube context (optional)")
+	rootCmd.PersistentFlags().String("kubeconfig", kubeConfigDefaultPath, "config path (optional)")
+
 	rootCmd.AddCommand(trafficCmd)
 	rootCmd.AddCommand(versionCmd)
 }
 
-func setup() {
-	kubeConfigPath := homedir.HomeDir() + "/.kube/config"
+func clientSetup(kubeContext string, kubeConfigPath string) {
 	var err error
-	clients, err = client.New(kubeConfigPath)
+
+	clients, err = client.New(kubeContext, kubeConfigPath)
 	if err != nil {
 		logger.Fatal(fmt.Sprintf("%s", err), "cmd")
 	}
+	logger.Debug(fmt.Sprintf("Initialized client from context '%s' and kubeConfig '%s'", kubeContext, kubeConfigPath), "cmd")
 
 	// generate random uuid
 	tracking, err := uuid.NewUUID()
@@ -64,6 +69,7 @@ Istiops is a CLI library for Go that manages istio's traffic shifting easily.
 	`,
 }
 
+// Execute will execute the cmd client
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		logger.Fatal(fmt.Sprintf("%s", err), "cmd")

--- a/cmd/shift.go
+++ b/cmd/shift.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/pismo/istiops/pkg/logger"
 	"github.com/pismo/istiops/pkg/router"
 	"github.com/spf13/cobra"
-	"strconv"
-	"strings"
 )
 
 func init() {
@@ -31,6 +32,9 @@ var shiftCmd = &cobra.Command{
 	Use:   "shift",
 	Short: "Shift istio's traffic",
 	Run: func(cmd *cobra.Command, args []string) {
+		kubeContext, _ := rootCmd.Flags().GetString("context")
+		kubeConfigPath, _ := rootCmd.Flags().GetString("kubeconfig")
+		clientSetup(kubeContext, kubeConfigPath)
 
 		namespace := cmd.Flag("namespace").Value.String()
 		if namespace == "" {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/ghodss/yaml"
 	"github.com/gookit/color"
 	"github.com/pismo/istiops/pkg/logger"
@@ -225,6 +226,9 @@ var showCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show current istio's traffic rules",
 	Run: func(cmd *cobra.Command, args []string) {
+		kubeContext, _ := rootCmd.Flags().GetString("context")
+		kubeConfigPath, _ := rootCmd.Flags().GetString("kubeconfig")
+		clientSetup(kubeContext, kubeConfigPath)
 
 		namespace := cmd.Flag("namespace").Value.String()
 		if namespace == "" {

--- a/cmd/traffic.go
+++ b/cmd/traffic.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
 	"os"
+
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -15,6 +16,10 @@ var trafficCmd = &cobra.Command{
 	Use:   "traffic",
 	Short: "Manage istio's traffic rules",
 	Run: func(cmd *cobra.Command, args []string) {
+		kubeContext, _ := rootCmd.Flags().GetString("context")
+		kubeConfigPath, _ := rootCmd.Flags().GetString("kubeconfig")
+		clientSetup(kubeContext, kubeConfigPath)
+
 		_ = cmd.Usage()
 		os.Exit(1)
 	},

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -9,6 +10,6 @@ var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Shows current build version",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("2.1.0")
+		fmt.Println("2.2.0")
 	},
 }

--- a/go.sum
+++ b/go.sum
@@ -121,5 +121,7 @@ k8s.io/api v0.0.0-20180308224125-73d903622b73 h1:5Z+PFfTIOXwKmOhQtZ0WBykbpGBBOuv
 k8s.io/api v0.0.0-20180308224125-73d903622b73/go.mod h1:iuAfoD4hCxJ8Onx9kaTIt30j7jUFS00AXQi6QMi99vA=
 k8s.io/apimachinery v0.0.0-20180228050457-302974c03f7e h1:CsgbEA8905OlpVLNKWD4GacPex50kFbqhotVNPew+dU=
 k8s.io/apimachinery v0.0.0-20180228050457-302974c03f7e/go.mod h1:ccL7Eh7zubPUSh9A3USN90/OzHNSVN6zxzde07TDCL0=
+k8s.io/client-go v1.5.1 h1:XaX/lo2/u3/pmFau8HN+sB5C/b4dc4Dmm2eXjBH4p1E=
 k8s.io/client-go v7.0.0+incompatible h1:kiH+Y6hn+pc78QS/mtBfMJAMIIaWevHi++JvOGEEQp4=
 k8s.io/client-go v7.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
+k8s.io/client-go v11.0.0+incompatible h1:LBbX2+lOwY9flffWlJM7f1Ct8V2SRNiMRDFeiwnJo9o=

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,43 +1,62 @@
 package client
 
 import (
-	"fmt"
 	"github.com/aspenmesh/istio-client-go/pkg/client/clientset/versioned"
-	"github.com/pismo/istiops/pkg/logger"
 	"github.com/pismo/istiops/pkg/router"
 	"k8s.io/client-go/kubernetes"
+
+	// in order to solve a gcp bug when trying to get the kubeconfig
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+// Set will define both kubernetes and istio interfaces
 type Set struct {
 	Kubernetes kubernetes.Interface
 	Istio      router.IstioClientInterface
 }
 
-func New(kubeConfigPath string) (*Set, error) {
+// ToRawKubeConfigLoader returns a ClientConfig with overrided attributes such as 'context'
+func ToRawKubeConfigLoader(kubeContext string, kubeConfigPath string) clientcmd.ClientConfig {
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	// if you want to change the loading rules (which files in which order), you can do so here
+	loadingRules.ExplicitPath = kubeConfigPath
+
+	// if you want to change override values or bind them to flags, there are methods to help you
+	configOverrides := &clientcmd.ConfigOverrides{
+		ClusterDefaults: clientcmd.ClusterDefaults,
+	}
+
+	if kubeContext != "" {
+		configOverrides.CurrentContext = kubeContext
+	}
+
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	return kubeConfig
+}
+
+// New will return a clientset with both kubernetes and istio ones
+func New(kubeContext string, kubeConfigPath string) (*Set, error) {
 	var istioClient router.IstioClientInterface
 	var config *rest.Config
 	var err error
-	config, err = clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+
+	config, err = ToRawKubeConfigLoader(kubeContext, kubeConfigPath).ClientConfig()
 	if err != nil {
-		logger.Error(fmt.Sprintf("Error while loading ./kube/config file %s", err.Error()), "bootstart")
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			logger.Error(fmt.Sprintf("Error while loading kubernetes conf (inside pod) %s", err.Error()), "bootstart")
-		}
+		return &Set{}, err
 	}
 
-	// create the clientset
+	// create both clientset
 	kubeClient, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		panic(err.Error())
+		return &Set{}, err
 	}
 
 	istioClient, err = versioned.NewForConfig(config)
 	if err != nil {
-		panic(err.Error())
+		return &Set{}, err
 	}
 
 	client := &Set{

--- a/pkg/router/virtualservice_test.go
+++ b/pkg/router/virtualservice_test.go
@@ -276,7 +276,7 @@ func TestVirtualService_Clear_Soft_Integrated(t *testing.T) {
 	}
 
 	labelsNoPods := map[string]string{
-		"app": "api-test",
+		"app":  "api-test",
 		"pods": "0",
 	}
 	tvs.Labels = labels
@@ -642,7 +642,7 @@ func TestVirtualService_Clear_Soft_Integrated_WithoutPods(t *testing.T) {
 	assert.EqualError(t, err, "empty routes when cleaning virtualService's rules")
 }
 
-func TestVirtualService_Clear_Soft_Integrated_Without_Destination_Rules(t *testing.T){
+func TestVirtualService_Clear_Soft_Integrated_Without_Destination_Rules(t *testing.T) {
 	fakeIstioClient = istioFake.NewSimpleClientset()
 	fakeKubeClient = kubeFake.NewSimpleClientset()
 
@@ -663,11 +663,11 @@ func TestVirtualService_Clear_Soft_Integrated_Without_Destination_Rules(t *testi
 		Port:     0,
 		Hostname: "",
 		Selector: labelSelector,
-		Traffic: Traffic{},
+		Traffic:  Traffic{},
 	}
 
 	err := vs.Clear(shift, "")
-	assert.EqualError(t, err,"could not find any destinationRules which matched label-selector 'environment=integration-tests'")
+	assert.EqualError(t, err, "could not find any destinationRules which matched label-selector 'environment=integration-tests'")
 }
 
 func TestVirtualService_Clear_Soft_Integrated_Without_Mode(t *testing.T) {


### PR DESCRIPTION
This PR adds the optional  `kubeConfig` and `kubeContext` options/flags to the kubernetes and istio clients. In case of a missing input for both of them it will respective be replaced by: `~/.kube/config` and `current-context`. Example:


```
istiops traffic show \
    -l "app=api-domain" \
    -n "default" \
    --kubeconfig "/tmp/kube-config"
```

```
istiops traffic show \
    -l "app=api-domain" \
    -n "default" \
    --context eks_eks-my-custom-context
```